### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/src/scrub_stderr.jl
+++ b/src/scrub_stderr.jl
@@ -4,19 +4,19 @@ export scrub_stderr, scrub_redefinition_warnings, no_warnings, sinclude
 
 # O nameless stranger, please improve my ailing regexes.
 redefinition_regexes =
-    [r"WARNING\\: Method definition .* in module .* at .* overwritten at .*\n",
-     r"WARNING\\: Method definition .* in module .* overwritten\.\n",
-     r"WARNING\\: replacing docs for .*\n",
+    [r"WARNING: Method definition .* in module .* at .* overwritten at .*\n",
+     r"WARNING: Method definition .* in module .* overwritten.\n",
+     r"WARNING: replacing docs for .*\n",
      # 0.6 updated its doc warnings with color. Looks like this:
      # \e[1m\e[33mWARNING: \e[39m\e[22m\e[33mreplacing
      r".*WARNING: .*replacing docs for .*\n",
-     r"WARNING\\: redefining constant .*\n"]
+     r"WARNING: redefining constant .*\n"]
 
 
 """ `scrub_stderr(body::Function, pats::Regex...)` executes `body` without
 outputting any warning that matches one of the `pats`.
 
-Pattern example: r"WARNING\\: redefining constant .*\n" """
+Pattern example: r"WARNING: redefining constant .*\n" """
 function scrub_stderr(body::Function, pats::Regex...)
     mktemp() do _, f
         old_stderr = STDERR

--- a/src/scrub_stderr.jl
+++ b/src/scrub_stderr.jl
@@ -16,7 +16,7 @@ redefinition_regexes =
 """ `scrub_stderr(body::Function, pats::Regex...)` executes `body` without
 outputting any warning that matches one of the `pats`.
 
-Pattern example: r"WARNING: redefining constant .*\n" """
+Pattern example: r"WARNING\\: redefining constant .*\n" """
 function scrub_stderr(body::Function, pats::Regex...)
     mktemp() do _, f
         old_stderr = STDERR

--- a/src/scrub_stderr.jl
+++ b/src/scrub_stderr.jl
@@ -16,7 +16,7 @@ redefinition_regexes =
 """ `scrub_stderr(body::Function, pats::Regex...)` executes `body` without
 outputting any warning that matches one of the `pats`.
 
-Pattern example: r"WARNING\: redefining constant .*\n" """
+Pattern example: r"WARNING\\: redefining constant .*\n" """
 function scrub_stderr(body::Function, pats::Regex...)
     mktemp() do _, f
         old_stderr = STDERR

--- a/src/scrub_stderr.jl
+++ b/src/scrub_stderr.jl
@@ -16,7 +16,7 @@ redefinition_regexes =
 """ `scrub_stderr(body::Function, pats::Regex...)` executes `body` without
 outputting any warning that matches one of the `pats`.
 
-Pattern example: r"WARNING\\: redefining constant .*\n" """
+Pattern example: r"WARNING: redefining constant .*\n" """
 function scrub_stderr(body::Function, pats::Regex...)
     mktemp() do _, f
         old_stderr = STDERR

--- a/src/scrub_stderr.jl
+++ b/src/scrub_stderr.jl
@@ -4,13 +4,13 @@ export scrub_stderr, scrub_redefinition_warnings, no_warnings, sinclude
 
 # O nameless stranger, please improve my ailing regexes.
 redefinition_regexes =
-    [r"WARNING\: Method definition .* in module .* at .* overwritten at .*\n",
-     r"WARNING\: Method definition .* in module .* overwritten\.\n",
-     r"WARNING\: replacing docs for .*\n",
+    [r"WARNING\\: Method definition .* in module .* at .* overwritten at .*\n",
+     r"WARNING\\: Method definition .* in module .* overwritten\.\n",
+     r"WARNING\\: replacing docs for .*\n",
      # 0.6 updated its doc warnings with color. Looks like this:
      # \e[1m\e[33mWARNING: \e[39m\e[22m\e[33mreplacing
      r".*WARNING: .*replacing docs for .*\n",
-     r"WARNING\: redefining constant .*\n"]
+     r"WARNING\\: redefining constant .*\n"]
 
 
 """ `scrub_stderr(body::Function, pats::Regex...)` executes `body` without


### PR DESCRIPTION
ON 0.7 I get
```julia
julia> using ClobberingReload
INFO: Precompiling module ClobberingReload.
ERROR: LoadError: LoadError: syntax: invalid escape sequence
Stacktrace:
 [1] include_relative(::Module, ::String) at .\loading.jl:464
 [2] include at .\sysimg.jl:14 [inlined]
 [3] include(::String) at C:\Users\Mus\.julia\v0.7\ClobberingReload\src\ClobberingReload.jl:3
 [4] include_relative(::Module, ::String) at .\loading.jl:464
 [5] include(::Module, ::String) at .\sysimg.jl:14
 [6] anonymous at .\<missing>:2
while loading C:\Users\Mus\.julia\v0.7\ClobberingReload\src\scrub_stderr.jl, in expression starting on line 19
while loading C:\Users\Mus\.julia\v0.7\ClobberingReload\src\ClobberingReload.jl, in expression starting on line 11
ERROR: Failed to precompile ClobberingReload to C:\Users\Mus\.julia\lib\v0.7\ClobberingReload.ji.
```