### PR TITLE
Thrown error looks for an undefined exception

### DIFF
--- a/src/ClobberingReload.jl
+++ b/src/ClobberingReload.jl
@@ -42,7 +42,7 @@ function parse_module_file(fname::String)
             return modname, code
         end
     end
-    error("ClobberingReload error: Cannot parse $fname; must contain a module. Exception $e")
+    error("ClobberingReload error: Cannot parse $fname; must contain a module.")
 end
 
 is_typealias(expr) =


### PR DESCRIPTION
Currently if ClobberingReload fails to parse the module it tries to blame things on Euler:

```
ClobberingReload error: Cannot parse C:\Users\Alex\.julia\v0.6\Hanabi\src\Hanabi.jl; 
must contain a module. Exception e = 2.7182818284590...
```